### PR TITLE
Example scroll fix

### DIFF
--- a/Javascript/demos/browser/features/support/pages/homepage.page.js
+++ b/Javascript/demos/browser/features/support/pages/homepage.page.js
@@ -28,6 +28,28 @@ export default new class Homepage extends PageObject {
   }
 
   interactWithPageObjectsAPI = async () => {
+    const retryActionOnElement = async (attempts, element, action, ...args) => {
+      let counter = attempts;
+    
+      while (counter > 0) {
+        await testEvolve.browser.scroll.to(element);
+    
+        try {
+          if (args.length === 0) {
+            await element[action]();
+          } else {
+            await element[action](...args);
+          }
+          break;
+        } catch (error) {
+          counter -= 1;
+          if (counter <= 0) {
+            throw error;
+          };
+        };
+      };
+    };
+
     try {
       if (await this.myBanner.isDisplayed()) {
         await this.myBanner.click();
@@ -72,9 +94,9 @@ export default new class Homepage extends PageObject {
 
     await this.number.set("12345");
     await testEvolve.browser.scroll.to(this.myRadio);
-    await this.myRadio.click();
-    await this.myRadio2.click();
-    await this.myCheckbox.check();
+    await retryActionOnElement(10, this.myRadio, 'click');
+    await retryActionOnElement(10, this.myRadio2, 'click');
+    await retryActionOnElement(10, this.myCheckbox, 'check');
     await this.mySelect.selectValue("Option 3")
     await this.buttonDouble.doubleClick();
     await this.email.set('test@test.com');

--- a/Ruby/demos/browser/features/support/pages/homepage.rb
+++ b/Ruby/demos/browser/features/support/pages/homepage.rb
@@ -27,6 +27,26 @@ module Pages
     element(:button_double) { button(data_test: 'example-double') }
     element(:email) { text_field(data_test: 'example-email') }
 
+    def retry_action_on_element(attempts, element, action, *args)
+      counter = attempts
+
+      while counter.positive?
+        element.scroll.to
+
+        begin
+          if args.empty?
+            element.send(action)
+          else
+            element.send(action, *args)
+          end
+          break
+
+        rescue StandardError
+          counter -= 1
+        end
+      end
+    end
+
     def interact_with_page_objects()
       my_banner.click if my_banner.present?
       my_link.click
@@ -52,10 +72,9 @@ module Pages
       password.set('my secret')
       raise "Expected: 'my secret', Actual: #{password.value}" unless password.value == 'my secret'
       number.set("12345")
-      my_radio.scroll.to
-      my_radio.click
-      my_radio_2.click
-      my_checkbox.check
+      retry_action_on_element(5, my_radio, :click)
+      retry_action_on_element(5, my_radio_2, :click)
+      retry_action_on_element(5, my_checkbox, :check)
       my_select.select('Option 3')
       button_double.double_click
       email.set('test@test.com')


### PR DESCRIPTION
Add method to Spark Ruby+JS project example tests to retry scroll and click/set action

Method is used only for failing tests