### PR TITLE
tsconfig.json error fix

### DIFF
--- a/Typescript/template/tsconfig.json
+++ b/Typescript/template/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "outDir": "./dist",
     "target": "ES2021",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
Add outputDir to tsconfig.json to prevent errors when cucumber.js file is present in root and would be overwritten by compiler